### PR TITLE
 Integrated MongoDB docker components for CI

### DIFF
--- a/.github/workflows/maven-run-tests.yml
+++ b/.github/workflows/maven-run-tests.yml
@@ -5,7 +5,7 @@ name: Java CI with Maven
 
 on:
   pull_request:
-    branches: [ development ]
+    branches: [ development, main ]
 
 jobs:
   build:
@@ -29,6 +29,24 @@ jobs:
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
+          
+      mongo:
+        # Mongo Docker Hub image
+        image: mongo
+        # Provide the username, password and connection string for mongo
+        env:
+          ME_CONFIG_MONGODB_ADMINUSERNAME: admin
+          ME_CONFIG_MONGODB_ADMINPASSWORD: admin
+          ME_CONFIG_MONGODB_URL: mongodb://admin:admin@mongo:27017/
+        # Set health checks to wait until mongo has started  
+        options: >-
+                --health-cmd mongo
+                --health-interval 10s
+                --health-timeout 5s
+                --health-retries 5
+        # Maps tcp port 27017 on service container to the host
+        ports:
+          - 27017:27017
     
     steps:
     - uses: actions/checkout@v2
@@ -41,6 +59,8 @@ jobs:
         settings-path: ${{ github.workspace }} # location for the settings.xml file
     - name: Setup Postgres
       run: psql -f ci/sql/setup_postgres.sql postgresql://postgres:admin@localhost:5432/postgres
+    - name: Check status of Mongo
+      run: mongo test --eval "printjson(db.getSiblingDB('TestDB'), db.getCollectionNames())"
     - name: Build with Maven
       run: |
         mkdir -p ~/.m2
@@ -48,4 +68,3 @@ jobs:
         mvn -B package --file basyx.components/pom.xml
       env:       
         GITHUB_TOKEN: ${{ github.token }}
-

--- a/.github/workflows/maven-run-tests.yml
+++ b/.github/workflows/maven-run-tests.yml
@@ -5,7 +5,7 @@ name: Java CI with Maven
 
 on:
   pull_request:
-    branches: [ development, main ]
+    branches: [ development ]
 
 jobs:
   build:

--- a/basyx.components/pom.xml
+++ b/basyx.components/pom.xml
@@ -97,8 +97,6 @@
 						<excludes>
 							<exclude>**/*HTTP*</exclude>
 							<exclude>**/*TCP*</exclude>
-							<!-- Exclude explicit MongoDB tests for CI -->
-							<exclude>**/*MongoDB*</exclude>
 						</excludes>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
Dear Frank,

I have integrated the MongoDB docker components to enable MongoDB tests in CI.

Following is the link for the successful run of the CI in my fork:
https://github.com/mdanish98/basyx-java-components/runs/4347289301?check_suite_focus=true

Thanks and Regards
Mohammad