### PR TITLE
Update basyx.tck and sdk version to 1.1.0-SNAPSHOT

### DIFF
--- a/basyx.tck/pom.xml
+++ b/basyx.tck/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.basyx</groupId>
   <artifactId>basyx.tck</artifactId>
-  <version>1.0.1</version>
+  <version>1.1.0-SNAPSHOT</version> 
   
   
   <packaging>pom</packaging>
@@ -111,13 +111,13 @@
 			<dependency>
 				<groupId>org.eclipse.basyx</groupId>
 				<artifactId>basyx.sdk</artifactId>
-				<version>1.0.1</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 			<!-- BaSyx SDK tests -->
 			<dependency>
 				<groupId>org.eclipse.basyx</groupId>
 				<artifactId>basyx.sdk</artifactId>
-				<version>1.0.1</version>
+				<version>1.1.0-SNAPSHOT</version>
 				<classifier>tests</classifier>
 				<scope>test</scope>
 			</dependency>


### PR DESCRIPTION
Updated version in the basyx.tck parent otherwise the modules of basyx.tck will not build. Also updated the basyx sdk version to 1.1.0-SNAPSHOT