### PR TITLE
Fixed github issue (#11) possible passing of NullPointer for Registry Proxy in MongoDBAASAggregator

### DIFF
--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/pom.xml
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/pom.xml
@@ -66,6 +66,7 @@
 			<groupId>org.eclipse.basyx</groupId>
 			<artifactId>basyx.components.registry</artifactId>
 			<version>1.0.3</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	

--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/pom.xml
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/pom.xml
@@ -61,7 +61,12 @@
 			<artifactId>poi-ooxml</artifactId>
 			<version>4.1.2</version>
 		</dependency>
-		
+
+		<dependency>
+			<groupId>org.eclipse.basyx</groupId>
+			<artifactId>basyx.components.registry</artifactId>
+			<version>1.0.3</version>
+		</dependency>
 	</dependencies>
 	
 	<profiles>

--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/AASServerComponent.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/AASServerComponent.java
@@ -340,7 +340,7 @@ public class AASServerComponent implements IComponent {
 		} else {
 			config = this.mongoDBConfig;
 		}
-		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(config);
+		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(config, registry);
 		aggregator.setRegistry(registry);
 		return aggregator;
 	}

--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/AASServerComponent.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/AASServerComponent.java
@@ -341,7 +341,6 @@ public class AASServerComponent implements IComponent {
 			config = this.mongoDBConfig;
 		}
 		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(config, registry);
-		aggregator.setRegistry(registry);
 		return aggregator;
 	}
 }

--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mongodb/MongoDBAASAggregator.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mongodb/MongoDBAASAggregator.java
@@ -95,18 +95,47 @@ public class MongoDBAASAggregator implements IAASAggregator {
 		this.setConfiguration(config);
 		init();
 	}
+	
+	/**
+	 * Receives the path of the configuration.properties file and the registry in it's constructor.
+	 * 
+	 * @param configFilePath
+	 * @param registry
+	 */
+	public MongoDBAASAggregator(BaSyxMongoDBConfiguration config, IAASRegistry registry) {
+		this.setConfiguration(config);
+		this.registry = registry;
+		init();
+	}
 
+	@Deprecated
 	public void setRegistry(IAASRegistry registry) {
 		this.registry = registry;
 	}
 
 	/**
 	 * Receives the path of the .properties file in it's constructor from a resource.
+	 * 
+	 * @param Path of the configuration file
 	 */
 	public MongoDBAASAggregator(String resourceConfigPath) {
 		config = new BaSyxMongoDBConfiguration();
 		config.loadFromResource(resourceConfigPath);
 		this.setConfiguration(config);
+		init();
+	}
+	
+	/**
+	 * Receives the path of the .properties file from a resource and the registry in it's constructor.
+	 * 
+	 * @param Path of the configuration file
+	 * @param registry
+	 */
+	public MongoDBAASAggregator(String resourceConfigPath, IAASRegistry registry) {
+		config = new BaSyxMongoDBConfiguration();
+		config.loadFromResource(resourceConfigPath);
+		this.setConfiguration(config);
+		this.registry = registry;
 		init();
 	}
 
@@ -115,6 +144,15 @@ public class MongoDBAASAggregator implements IAASAggregator {
 	 */
 	public MongoDBAASAggregator() {
 		this(DEFAULT_CONFIG_PATH);
+	}
+	
+	/**
+	 * Constructor using default connections with registry as a parameter
+	 * 
+	 * @param registry
+	 */
+	public MongoDBAASAggregator(IAASRegistry registry) {
+		this(DEFAULT_CONFIG_PATH, registry);
 	}
 
 	/**
@@ -282,5 +320,9 @@ public class MongoDBAASAggregator implements IAASAggregator {
 		}
 
 		return provider;
+	}
+	
+	public boolean isRegistryNull() {
+		return this.registry == null;
 	}
 }

--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mongodb/MongoDBAASAggregator.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mongodb/MongoDBAASAggregator.java
@@ -11,14 +11,12 @@ package org.eclipse.basyx.components.aas.mongodb;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import org.eclipse.basyx.aas.aggregator.AASAggregator;
 import org.eclipse.basyx.aas.aggregator.api.IAASAggregator;
 import org.eclipse.basyx.aas.metamodel.api.IAssetAdministrationShell;
@@ -49,7 +47,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
-
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 
@@ -107,7 +104,18 @@ public class MongoDBAASAggregator implements IAASAggregator {
 		this.registry = registry;
 		init();
 	}
-
+	
+	/**
+	 * Sets the IAASRegistry instance.
+	 * 
+	 * @deprecated This method is deprecated due to a bug. 
+	 * Use constructors {@link #MongoDBAASAggregator(IAASRegistry) 
+	 * or #MongoDBAASAggregator(BaSyxMongoDBConfiguration, IAASRegistry) 
+	 * or #MongoDBAASAggregator(String, IAASRegistry) }
+	 * to set the IAASRegistry instance.
+	 * 
+	 * @param Asset Adminstration Shell's Registry
+	 */
 	@Deprecated
 	public void setRegistry(IAASRegistry registry) {
 		this.registry = registry;
@@ -320,9 +328,5 @@ public class MongoDBAASAggregator implements IAASAggregator {
 		}
 
 		return provider;
-	}
-	
-	public boolean isRegistryNull() {
-		return this.registry == null;
 	}
 }

--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/test/java/org/eclipse/basyx/regression/AASServer/TestMongoDBAggregator.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/test/java/org/eclipse/basyx/regression/AASServer/TestMongoDBAggregator.java
@@ -10,16 +10,12 @@
 package org.eclipse.basyx.regression.AASServer;
 
 import static org.junit.Assert.assertEquals;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-
 import javax.xml.parsers.ParserConfigurationException;
-
 import org.eclipse.basyx.aas.aggregator.api.IAASAggregator;
 import org.eclipse.basyx.aas.manager.ConnectedAssetAdministrationShellManager;
-import org.eclipse.basyx.aas.metamodel.api.IAssetAdministrationShell;
 import org.eclipse.basyx.aas.metamodel.map.AssetAdministrationShell;
 import org.eclipse.basyx.aas.metamodel.map.descriptor.ModelUrn;
 import org.eclipse.basyx.aas.registration.api.IAASRegistry;
@@ -35,7 +31,9 @@ import org.eclipse.basyx.submodel.metamodel.api.identifier.IIdentifier;
 import org.eclipse.basyx.submodel.metamodel.api.identifier.IdentifierType;
 import org.eclipse.basyx.submodel.metamodel.map.Submodel;
 import org.eclipse.basyx.submodel.metamodel.map.identifier.Identifier;
+import org.eclipse.basyx.submodel.metamodel.map.qualifier.Referable;
 import org.eclipse.basyx.testsuite.regression.aas.aggregator.AASAggregatorSuite;
+import org.eclipse.basyx.vab.exception.provider.ResourceNotFoundException;
 import org.eclipse.basyx.vab.modelprovider.api.IModelProvider;
 import org.eclipse.basyx.vab.protocol.api.IConnectorFactory;
 import org.eclipse.basyx.vab.protocol.http.connector.HTTPConnectorFactory;
@@ -45,21 +43,31 @@ import org.junit.Test;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.xml.sax.SAXException;
 import org.eclipse.basyx.aas.registration.memory.AASRegistry;
-import org.eclipse.basyx.aas.registration.memory.InMemoryRegistry;
 import org.eclipse.basyx.aas.restapi.MultiSubmodelProvider;
-
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 
-
+/**
+ * Testing various behaviors of MongoDBAASAggregator
+ * Using MongoDBAASAggregator's constructors to set registry and adding AAS
+ * and Submodels from MongoDB
+ * 
+ * @author danish
+ *
+ */
 public class TestMongoDBAggregator extends AASAggregatorSuite {
 	private static final Identifier SM_IDENTIFICATION = new Identifier(IdentifierType.CUSTOM, "MongoDBId");
 	private static final String SM_IDSHORT = "MongoDB";
+	private static final String PREFIX_SUBMODEL_PATH = "/aas/submodels/";
+	private static final String SUFFIX_SUBMODEL_PATH = "/submodel";
+	private static final String SUFFIX_COMPONENT_URL = "/shells";
+	
 	private static AASServerComponent component;
 	private static BaSyxMongoDBConfiguration mongoDBConfig;
 	private static BaSyxContextConfiguration contextConfig;
 	private static BaSyxAASServerConfiguration aasConfig;
 	private static IAASRegistry registry;
+	
 	protected static ConnectedAssetAdministrationShellManager manager;
 	protected static String aasId = "testId";
 	
@@ -69,10 +77,7 @@ public class TestMongoDBAggregator extends AASAggregatorSuite {
 		resetMongoDBTestData();
 		
 		component = new AASServerComponent(contextConfig, aasConfig, mongoDBConfig);
-		registry = new AASRegistry(new MongoDBRegistryHandler("mongodb.properties"));
-//		registry.delete(new ModelUrn(aasId));
-		
-		System.out.println("Initial Registry status All: " + registry.lookupAll());
+		registry = new AASRegistry(new MongoDBRegistryHandler(BaSyxMongoDBConfiguration.DEFAULT_CONFIG_PATH));
 		
 		IConnectorFactory connectorFactory = new HTTPConnectorFactory();
 	
@@ -80,21 +85,9 @@ public class TestMongoDBAggregator extends AASAggregatorSuite {
 		
 		component.setRegistry(registry);
 		component.startComponent();
-	}
-	
-	public void setUpClass2() throws ParserConfigurationException, SAXException, IOException {
-		initConfiguration();
-//		resetMongoDBTestData();
 		
-//		component = new AASServerComponent(contextConfig, aasConfig, mongoDBConfig);
-		registry = new AASRegistry(new MongoDBRegistryHandler("mongodb.properties"));
-		
-		IConnectorFactory connectorFactory = new HTTPConnectorFactory();
-	
-		manager = new ConnectedAssetAdministrationShellManager(registry, connectorFactory);
-		
-		component.setRegistry(registry);
-		component.startComponent();
+		createAssetAdministrationShell();
+		createSubmodel();
 	}
 	
 	private static void initConfiguration() {
@@ -111,7 +104,27 @@ public class TestMongoDBAggregator extends AASAggregatorSuite {
 	private static void resetMongoDBTestData() {
 		new MongoDBAASAggregator(mongoDBConfig).reset();
 	}
-
+	
+	private static void createAssetAdministrationShell() {
+		AssetAdministrationShell assetAdministrationShell = new AssetAdministrationShell();
+		
+		IIdentifier identifier = new ModelUrn(aasId);
+		
+		assetAdministrationShell.setIdentification(identifier);
+		assetAdministrationShell.setIdShort("aasIdShort");
+		
+		manager.createAAS(assetAdministrationShell, getURL());
+	}
+	
+	protected static String getURL() {
+		return component.getURL() + SUFFIX_COMPONENT_URL;
+	}
+	
+	private static void createSubmodel() {
+		Submodel sm = new Submodel(SM_IDSHORT, SM_IDENTIFICATION);
+		manager.createSubmodel(new ModelUrn(aasId), sm);
+	}
+	
 	@Test
 	public void testDeleteReachesDatabase() {
 		final BaSyxMongoDBConfiguration config = new BaSyxMongoDBConfiguration();
@@ -166,139 +179,73 @@ public class TestMongoDBAggregator extends AASAggregatorSuite {
 	}
 	
 	@Test
-	public void checkForMongoDBAASAggregatorRegistryIsNotNull() throws Exception {
-		createAssetAdministrationShell();
-		createSubmodel();
-		
-		System.out.println("After creating submodel and aas Registry status AAS : " +  registry.lookupAll());
-
+	public void checkInitialSetupAfterCreatingAndRegisteringAasAndSubmodel() {
 		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(mongoDBConfig);
 		ISubmodel persistentSubmodel = getSubmodelFromAggregator(aggregator);
-		
-		System.out.println("After restarting aas Registry status AAS : " +  registry.lookupAAS(new ModelUrn(aasId)));
 
 		assertEquals(SM_IDSHORT, persistentSubmodel.getIdShort());
-	}
-	
-	private void restartServer() {
-		component.stopComponent();
-		System.out.println("Start the server after stop");
-		component.startComponent();
-	}
-	
-	private void getMongoDBConfig() {
-		mongoDBConfig = new BaSyxMongoDBConfiguration();
-		mongoDBConfig.setAASCollection("basyxTestAAS");
-		mongoDBConfig.setSubmodelCollection("basyxTestSM");
-	}
-	
-	@Test
-	public void checkMongoDBAASAggregatorRegistryIsNull() throws Exception {
-		getMongoDBConfig();
-		
-		System.out.println("Registry status : " + registry);
-		
-//		setUpClass2();
-		
-		restartServer();
-		
-		System.out.println("After setup call registry status : " + registry.lookupAll());
-		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(mongoDBConfig);
-		System.out.println("1 isRegistry Null : " + aggregator.isRegistryNull());
-		MultiSubmodelProvider aasProvider = (MultiSubmodelProvider) getSubmodelFromAggregator2(aggregator);
-		
-		Object submodelObject = aasProvider.getValue("/aas/submodels/" + SM_IDSHORT + "/submodel");
-		
-		System.out.println("shell =" + submodelObject);
-	}
-	
-	@Test
-	public void bugFixPassCase() throws Exception {
-		getMongoDBConfig();
-		
-		System.out.println("Registry status : " + registry);
-		
-//		setUpClass2();
-		
-		restartServer();
-		
-		System.out.println("After setup call registry status : " + registry.lookupAll());
-		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(mongoDBConfig);
-		System.out.println("1 isRegistry Null : " + aggregator.isRegistryNull());
-		MultiSubmodelProvider aasProvider = (MultiSubmodelProvider) getSubmodelFromAggregator2(aggregator);
-		
-		Object submodelObject = aasProvider.getValue("/aas/submodels/" + SM_IDSHORT + "/submodel");
-		
-		System.out.println("shell =" + submodelObject);
-	}
-	
-	public void checkPersistencyOfAggregator() throws Exception {
-//		createAssetAdministrationShell();
-//		createSubmodel();
-		
-		System.out.println("After creating submodel and aas Registry status AAS : " +  registry.lookupAll());
-
-		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(mongoDBConfig, registry);
-		ISubmodel persistentSubmodel = getSubmodelFromAggregator(aggregator);
-		
-//		component.stopComponent();
-		
-		component = new AASServerComponent(contextConfig, aasConfig, mongoDBConfig);
-		component.startComponent();
-		
-		MongoDBAASAggregator aggregator2 = new MongoDBAASAggregator(mongoDBConfig, registry);
-		ISubmodel persistentSubmodel2 = getSubmodelFromAggregator(aggregator);
-		
-		System.out.println("After restarting aas Registry status AAS : " +  registry.lookupAAS(new ModelUrn(aasId)));
-
-		assertEquals(SM_IDSHORT, persistentSubmodel.getIdShort());
-	}
-	
-	private void createSubmodel() {
-		Submodel sm = new Submodel(SM_IDSHORT, SM_IDENTIFICATION);
-		manager.createSubmodel(new ModelUrn(aasId), sm);
 	}
 	
 	@SuppressWarnings("unchecked")
 	private ISubmodel getSubmodelFromAggregator(MongoDBAASAggregator aggregator) {
 		MultiSubmodelProvider aasProvider = (MultiSubmodelProvider) aggregator.getAASProvider(new ModelUrn(aasId));
 		
-		Object submodelObject = aasProvider.getValue("/aas/submodels/" + SM_IDSHORT + "/submodel");
+		Object submodelObject = aasProvider.getValue(PREFIX_SUBMODEL_PATH + SM_IDSHORT + SUFFIX_SUBMODEL_PATH);
 		
 		ISubmodel persistentSubmodel = Submodel.createAsFacade((Map<String, Object>) submodelObject);
 		
-		aasProvider.removeProvider(SM_IDSHORT);
+		removeProviderFromMultiSubmodelProviderHashMap(aasProvider);
 		
 		return persistentSubmodel;
 	}
 	
-	@SuppressWarnings("unchecked")
-	private IModelProvider getSubmodelFromAggregator2(MongoDBAASAggregator aggregator) {
-		MultiSubmodelProvider aasProvider = (MultiSubmodelProvider) aggregator.getAASProvider(new ModelUrn(aasId));
-		
+	private void removeProviderFromMultiSubmodelProviderHashMap(MultiSubmodelProvider aasProvider) {
 		aasProvider.removeProvider(SM_IDSHORT);
-		
-		return aasProvider;
-	}
-
-	private void createAssetAdministrationShell() {
-		AssetAdministrationShell assetAdministrationShell = new AssetAdministrationShell();
-		
-		IIdentifier identifier = new ModelUrn(aasId);
-		
-		assetAdministrationShell.setIdentification(identifier);
-		assetAdministrationShell.setIdShort("aasIdShort");
-		
-		manager.createAAS(assetAdministrationShell, getURL());
 	}
 	
-	protected String getURL() {
-		return component.getURL() + "/shells";
+	@Test(expected = ResourceNotFoundException.class)
+	public void checkForResourceNotFoundExceptionWhileNotPassingRegistryAfterServerRestart() {
+		restartAasServer();
+		
+		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(mongoDBConfig);
+		
+		MultiSubmodelProvider aasProvider = (MultiSubmodelProvider) getAssetAdministrationShellProviderFromMongoDBAggregator(aggregator);
+		
+		aasProvider.getValue(PREFIX_SUBMODEL_PATH + SM_IDSHORT + SUFFIX_SUBMODEL_PATH);
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void checkNoExceptionIsObservedAfterPassingRegistry() {	
+		restartAasServer();
+		
+		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(mongoDBConfig, registry);
+		MultiSubmodelProvider aasProvider = (MultiSubmodelProvider) getAssetAdministrationShellProviderFromMongoDBAggregator(aggregator);
+		
+		Map<String, Object> submodelObject = (Map<String, Object>) aasProvider.getValue(PREFIX_SUBMODEL_PATH + SM_IDSHORT + SUFFIX_SUBMODEL_PATH);
+
+		assertEquals(SM_IDSHORT, submodelObject.get(Referable.IDSHORT));
+	}
+	
+	private void restartAasServer() {
+		component.stopComponent();
+		component.startComponent();
+	}
+	
+	private IModelProvider getAssetAdministrationShellProviderFromMongoDBAggregator(MongoDBAASAggregator aggregator) {
+		MultiSubmodelProvider aasProvider = (MultiSubmodelProvider) aggregator.getAASProvider(new ModelUrn(aasId));
+		
+		removeProviderFromMultiSubmodelProviderHashMap(aasProvider);
+		
+		return aasProvider;
 	}
 	
 	@AfterClass
 	public static void tearDownClass() {
-//		resetMongoDBTestData();
+		registry.delete(new ModelUrn(aasId));
+		
+		resetMongoDBTestData();
+		
 		component.stopComponent();
 	}
 }

--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/test/java/org/eclipse/basyx/regression/AASServer/TestMongoDBAggregator.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/test/java/org/eclipse/basyx/regression/AASServer/TestMongoDBAggregator.java
@@ -11,38 +11,96 @@ package org.eclipse.basyx.regression.AASServer;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.basyx.aas.aggregator.api.IAASAggregator;
+import org.eclipse.basyx.aas.manager.ConnectedAssetAdministrationShellManager;
 import org.eclipse.basyx.aas.metamodel.map.AssetAdministrationShell;
+import org.eclipse.basyx.aas.metamodel.map.descriptor.ModelUrn;
+import org.eclipse.basyx.aas.registration.api.IAASRegistry;
+import org.eclipse.basyx.components.aas.AASServerComponent;
+import org.eclipse.basyx.components.aas.configuration.AASServerBackend;
+import org.eclipse.basyx.components.aas.configuration.BaSyxAASServerConfiguration;
 import org.eclipse.basyx.components.aas.mongodb.MongoDBAASAggregator;
 import org.eclipse.basyx.components.configuration.BaSyxContextConfiguration;
 import org.eclipse.basyx.components.configuration.BaSyxMongoDBConfiguration;
+import org.eclipse.basyx.components.registry.mongodb.MongoDBRegistryHandler;
+import org.eclipse.basyx.submodel.metamodel.api.ISubmodel;
+import org.eclipse.basyx.submodel.metamodel.api.identifier.IIdentifier;
+import org.eclipse.basyx.submodel.metamodel.api.identifier.IdentifierType;
+import org.eclipse.basyx.submodel.metamodel.map.Submodel;
+import org.eclipse.basyx.submodel.metamodel.map.identifier.Identifier;
 import org.eclipse.basyx.testsuite.regression.aas.aggregator.AASAggregatorSuite;
+import org.eclipse.basyx.vab.modelprovider.api.IModelProvider;
+import org.eclipse.basyx.vab.protocol.api.IConnectorFactory;
+import org.eclipse.basyx.vab.protocol.http.connector.HTTPConnectorFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.data.mongodb.core.MongoTemplate;
-
+import org.xml.sax.SAXException;
+import org.eclipse.basyx.aas.registration.memory.AASRegistry;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 
 
 public class TestMongoDBAggregator extends AASAggregatorSuite {
-
-	@Override
-	protected IAASAggregator getAggregator() {
-		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(BaSyxContextConfiguration.DEFAULT_CONFIG_PATH);
-		aggregator.reset();
-
-		return aggregator;
+	private static final Identifier SM_IDENTIFICATION = new Identifier(IdentifierType.CUSTOM, "MongoDBId");
+	private static final String SM_IDSHORT = "MongoDB";
+	private static AASServerComponent component;
+	private static BaSyxMongoDBConfiguration mongoDBConfig;
+	private static BaSyxContextConfiguration contextConfig;
+	private static BaSyxAASServerConfiguration aasConfig;
+	private static IAASRegistry registry;
+	protected static ConnectedAssetAdministrationShellManager manager;
+	protected static String aasId = "testId";
+	
+	@BeforeClass
+	public static void setUpClass() throws ParserConfigurationException, SAXException, IOException {
+		initConfiguration();
+		resetMongoDBTestData();
+		
+		component = new AASServerComponent(contextConfig, aasConfig, mongoDBConfig);
+		registry = new AASRegistry(new MongoDBRegistryHandler("mongodb.properties"));
+		
+		IConnectorFactory connectorFactory = new HTTPConnectorFactory();
+	
+		manager = new ConnectedAssetAdministrationShellManager(registry, connectorFactory);
+		
+		component.setRegistry(registry);
+		component.startComponent();
+	}
+	
+	private static void initConfiguration() {
+		mongoDBConfig = new BaSyxMongoDBConfiguration();
+		mongoDBConfig.setAASCollection("basyxTestAAS");
+		mongoDBConfig.setSubmodelCollection("basyxTestSM");
+		
+		contextConfig = new BaSyxContextConfiguration();
+		contextConfig.loadFromResource(BaSyxContextConfiguration.DEFAULT_CONFIG_PATH);
+		
+		aasConfig = new BaSyxAASServerConfiguration(AASServerBackend.MONGODB, "");
+	}
+	
+	private static void resetMongoDBTestData() {
+		new MongoDBAASAggregator(mongoDBConfig).reset();
 	}
 
 	@Test
 	public void testDeleteReachesDatabase() {
 		final BaSyxMongoDBConfiguration config = new BaSyxMongoDBConfiguration();
 		config.loadFromResource(BaSyxMongoDBConfiguration.DEFAULT_CONFIG_PATH);
+		
 		final MongoClient client = MongoClients.create(config.getConnectionUrl());
+		
 		final MongoTemplate mongoOps = new MongoTemplate(client, config.getDatabase());
+		
 		final String aasCollection = config.getAASCollection();
+		
 		final IAASAggregator aggregator = getAggregator();
 
 		// initial state: no data in the database
@@ -59,6 +117,7 @@ public class TestMongoDBAggregator extends AASAggregatorSuite {
 		// there should be that single AAS in the database
 		{
 			final List<AssetAdministrationShell> data = mongoOps.findAll(AssetAdministrationShell.class, aasCollection);
+			
 			assertEquals(1, data.size());
 			assertEquals(aas1.getIdentification(), data.get(0).getIdentification());
 		}
@@ -71,7 +130,78 @@ public class TestMongoDBAggregator extends AASAggregatorSuite {
 		// there should be no AAS in the database
 		{
 			final List<AssetAdministrationShell> data = mongoOps.findAll(AssetAdministrationShell.class, aasCollection);
+			
 			assertEquals(0, data.size());
 		}
+	}
+	
+	@Override
+	protected IAASAggregator getAggregator() {
+		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(BaSyxMongoDBConfiguration.DEFAULT_CONFIG_PATH);
+		aggregator.reset();
+
+		return aggregator;
+	}
+	
+	@Test
+	public void checkForMongoDBAASAggregatorRegistryIsNotNull() throws Exception {
+		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(mongoDBConfig, registry);
+		
+		assertEquals(false, aggregator.isRegistryNull());
+	}
+	
+	@Test
+	public void checkMongoDBAASAggregatorRegistryIsNull() throws Exception {
+		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(mongoDBConfig);
+
+		assertEquals(true, aggregator.isRegistryNull());
+	}
+	
+	@Test
+	public void checkPersistencyOfAggregator() throws Exception {
+		createAssetAdministrationShell();
+		createSubmodel();
+
+		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(mongoDBConfig, registry);
+		ISubmodel persistentSubmodel = getSubmodelFromAggregator(aggregator);
+
+		assertEquals(SM_IDSHORT, persistentSubmodel.getIdShort());
+	}
+	
+	private void createSubmodel() {
+		Submodel sm = new Submodel(SM_IDSHORT, SM_IDENTIFICATION);
+		manager.createSubmodel(new ModelUrn(aasId), sm);
+	}
+	
+	@SuppressWarnings("unchecked")
+	private ISubmodel getSubmodelFromAggregator(MongoDBAASAggregator aggregator) {
+		IModelProvider aasProvider = aggregator.getAASProvider(new ModelUrn(aasId));
+		
+		Object submodelObject = aasProvider.getValue("/aas/submodels/" + SM_IDSHORT + "/submodel");
+		
+		ISubmodel persistentSubmodel = Submodel.createAsFacade((Map<String, Object>) submodelObject);
+		
+		return persistentSubmodel;
+	}
+
+	private void createAssetAdministrationShell() {
+		AssetAdministrationShell assetAdministrationShell = new AssetAdministrationShell();
+		
+		IIdentifier identifier = new ModelUrn(aasId);
+		
+		assetAdministrationShell.setIdentification(identifier);
+		assetAdministrationShell.setIdShort("aasIdShort");
+		
+		manager.createAAS(assetAdministrationShell, getURL());
+	}
+	
+	protected String getURL() {
+		return component.getURL() + "/shells";
+	}
+	
+	@AfterClass
+	public static void tearDownClass() {
+		resetMongoDBTestData();
+		component.stopComponent();
 	}
 }

--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/test/java/org/eclipse/basyx/regression/AASServer/TestMongoDBAggregator.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/test/java/org/eclipse/basyx/regression/AASServer/TestMongoDBAggregator.java
@@ -212,6 +212,26 @@ public class TestMongoDBAggregator extends AASAggregatorSuite {
 		System.out.println("shell =" + submodelObject);
 	}
 	
+	@Test
+	public void bugFixPassCase() throws Exception {
+		getMongoDBConfig();
+		
+		System.out.println("Registry status : " + registry);
+		
+//		setUpClass2();
+		
+		restartServer();
+		
+		System.out.println("After setup call registry status : " + registry.lookupAll());
+		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(mongoDBConfig);
+		System.out.println("1 isRegistry Null : " + aggregator.isRegistryNull());
+		MultiSubmodelProvider aasProvider = (MultiSubmodelProvider) getSubmodelFromAggregator2(aggregator);
+		
+		Object submodelObject = aasProvider.getValue("/aas/submodels/" + SM_IDSHORT + "/submodel");
+		
+		System.out.println("shell =" + submodelObject);
+	}
+	
 	public void checkPersistencyOfAggregator() throws Exception {
 //		createAssetAdministrationShell();
 //		createSubmodel();

--- a/basyx.components/basyx.components.docker/pom.xml
+++ b/basyx.components/basyx.components.docker/pom.xml
@@ -174,7 +174,7 @@
 	
 	<!--  Defines common dependencies for all docker components -->
 	<dependencies>
-	<!-- Depends on the components library -->
+		<!-- Depends on the components library -->
 		<dependency>
 			<groupId>org.eclipse.basyx</groupId>
 			<artifactId>basyx.components.lib</artifactId>

--- a/basyx.components/basyx.components.docker/pom.xml
+++ b/basyx.components/basyx.components.docker/pom.xml
@@ -174,7 +174,7 @@
 	
 	<!--  Defines common dependencies for all docker components -->
 	<dependencies>
-		<!-- Depends on the components library -->
+	<!-- Depends on the components library -->
 		<dependency>
 			<groupId>org.eclipse.basyx</groupId>
 			<artifactId>basyx.components.lib</artifactId>

--- a/basyx.components/pom.xml
+++ b/basyx.components/pom.xml
@@ -79,8 +79,6 @@
 						<excludes>
 							<exclude>**/*HTTP*</exclude>
 							<exclude>**/*TCP*</exclude>
-							<!-- Exclude explicit MongoDB tests for CI -->
-							<exclude>**/*MongoDB*</exclude>
 						</excludes>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
Dear Frank,

Following are the changes done in this pull request:
- Fixed already present bug in TestMongoDBAggregator.getAggregator. It was using BaSyxContextConfiguration.DEFAULT_CONFIG_PATH instead of 
BaSyxMongoDBConfiguration.DEFAULT_CONFIG_PATH which resulted in failure.

- Fixed github issue (#11) possible passing of NullPointer for Registry Proxy in MongoDBAASAggregator.

- Added additional test cases in TestMongoDBAggregator.

- Modified pom.xml to enable MongoDB tests.

- Added basyx.components.registry as a dependency into basyx.components.AASServer because some test cases required this dependency.

As this bugfix branch has mongoDB CI disabled, please find below link of successful run in my forked repository.
https://github.com/mdanish98/basyx-java-components/runs/4480677365?check_suite_focus=true

Thanks and Regards
Mohammad