### PR TITLE
Adds JWT Bearer Token Authentication Config into context.properties

### DIFF
--- a/basyx.components/basyx.components.docker/basyx.components.registry/src/main/resources/context.properties
+++ b/basyx.components/basyx.components.docker/basyx.components.registry/src/main/resources/context.properties
@@ -21,11 +21,11 @@ contextHostname=localhost
 # ###############################
 # Specifies the port for this server context
 
-contextPort=4000
+contextPort=8080
 
 # ###############################
 # JWT Bearer Token Authentication
 # ###############################
-# jwtBearerTokenAuthenticationIssuerUri=http://localhost:9005/auth/realms/basyx-demo
-# jwtBearerTokenAuthenticationJwkSetUri=http://localhost:9005/auth/realms/basyx-demo/protocol/openid-connect/certs
-# jwtBearerTokenAuthenticationRequiredAud=aas-registry
+jwtBearerTokenAuthenticationIssuerUri=http://127.0.0.1:9006/auth/realms/basyx-demo
+jwtBearerTokenAuthenticationJwkSetUri=http://127.0.0.1:9006/auth/realms/basyx-demo/protocol/openid-connect/certs
+jwtBearerTokenAuthenticationRequiredAud=basyx-demo


### PR DESCRIPTION
Dear Frank,

This PR adds JWT Bearer Token Authentication Config into context.properties to successfully implement and run Authorized AAS Registry example.

Thanks and Regards
Mohammad

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>