### PR TITLE
 Quick-Fixes issue: Submodel Aggregator does not support multiple Submodels with same idShort

### DIFF
--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/AASServerComponent.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/AASServerComponent.java
@@ -332,12 +332,8 @@ public class AASServerComponent implements IComponent {
 
 	private IAASAggregator createMongoDbAggregatorWithMqttSubmodelAggregator() {
 		BaSyxMongoDBConfiguration config = createMongoDbConfiguration();
-		try {
-			MongoDBAASAggregator aggregator = new MongoDBAASAggregator(config, mqttConfig.getServer(), getMqttSubmodelClientId(), registry);
-			return aggregator;
-		} catch (MqttException e) {
-			throw new ProviderException("moquette.conf Error " + e.getMessage());
-		}
+		MongoDBAASAggregator aggregator = new MongoDBAASAggregator(config, mqttConfig.getServer(), getMqttSubmodelClientId(), registry);
+		return aggregator;
 	}
 
 	private BaSyxMongoDBConfiguration createMongoDbConfiguration() {

--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mongodb/MongoDBAASAggregator.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mongodb/MongoDBAASAggregator.java
@@ -130,7 +130,6 @@ public class MongoDBAASAggregator implements IAASAggregator {
 	 * @param config
 	 * @param serverEndpoint
 	 * @param clientId
-	 * @throws MqttException
 	 */
 	public MongoDBAASAggregator(BaSyxMongoDBConfiguration config, String serverEndpoint, String clientId) {
 		this.setConfiguration(config);
@@ -192,7 +191,6 @@ public class MongoDBAASAggregator implements IAASAggregator {
 	 * @param serverEndpoint
 	 * @param clientId
 	 * @param registry
-	 * @throws MqttException
 	 */
 	public MongoDBAASAggregator(BaSyxMongoDBConfiguration config, String serverEndpoint, String clientId,
 			IAASRegistry registry) {


### PR DESCRIPTION
 Quick-Fixes issue: Submodel Aggregator does not support multiple Submodels with same idShort

https://github.com/eclipse-basyx/basyx-java-sdk/issues/47

* Instantiate SubmodelAggregator for each MultiSubmodelProvider
* Add a quick-fix for MqttSubmodelAggregator (also now  instantiated for each MultiSubmodelProvider)
* TODO: Refactor MqttSubmodelAggregator instantiation (especially for the MqttException handling which is currenlty "truned off" by not throwing it to caller)

All tests passed locally for the quick-fix.

Signed-off-by: Matthias Stöhr <matthias.stoehr@ipa.fraunhofer.de>