### PR TITLE
Fixing mqtt auth and activating tagged directory env var

### DIFF
--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mqtt/MqttAASServerFeature.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mqtt/MqttAASServerFeature.java
@@ -9,12 +9,14 @@
  ******************************************************************************/
 package org.eclipse.basyx.components.aas.mqtt;
 
+import com.google.common.base.Strings;
 import java.security.ProviderException;
 
 import org.eclipse.basyx.components.aas.aascomponent.IAASServerDecorator;
 import org.eclipse.basyx.components.aas.aascomponent.IAASServerFeature;
 import org.eclipse.basyx.components.configuration.BaSyxMqttConfiguration;
 import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 
 /**
@@ -38,8 +40,13 @@ public class MqttAASServerFeature implements IAASServerFeature {
 	public void initialize() {
 		try {
 			String serverEndpoint = mqttConfig.getServer();
+			MqttConnectOptions options = new MqttConnectOptions();
+			if (!Strings.isNullOrEmpty(mqttConfig.getUser())) {
+				options.setUserName(mqttConfig.getUser());
+				options.setPassword(mqttConfig.getPass().toCharArray());
+			}
 			client = new MqttClient(serverEndpoint, clientId);
-			client.connect();
+			client.connect(options);
 		} catch (MqttException e) {
 			throw new ProviderException("moquette.conf Error ", e);
 		}

--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mqtt/MqttAASServerFeature.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mqtt/MqttAASServerFeature.java
@@ -18,6 +18,7 @@ import org.eclipse.basyx.components.configuration.BaSyxMqttConfiguration;
 import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * 
@@ -40,16 +41,21 @@ public class MqttAASServerFeature implements IAASServerFeature {
 	public void initialize() {
 		try {
 			String serverEndpoint = mqttConfig.getServer();
-			MqttConnectOptions options = new MqttConnectOptions();
-			if (!Strings.isNullOrEmpty(mqttConfig.getUser())) {
-				options.setUserName(mqttConfig.getUser());
-				options.setPassword(mqttConfig.getPass().toCharArray());
-			}
+			MqttConnectOptions options = createMqttConnectOptions();
 			client = new MqttClient(serverEndpoint, clientId);
 			client.connect(options);
 		} catch (MqttException e) {
 			throw new ProviderException("moquette.conf Error ", e);
 		}
+	}
+
+	protected MqttConnectOptions createMqttConnectOptions() {
+		MqttConnectOptions options = new MqttConnectOptions();
+		if (!Strings.isNullOrEmpty(mqttConfig.getUser())) {
+			options.setUserName(mqttConfig.getUser());
+			options.setPassword(mqttConfig.getPass().toCharArray());
+		}
+		return options;
 	}
 
 	@Override

--- a/basyx.components/basyx.components.docker/basyx.components.registry/src/main/java/org/eclipse/basyx/components/registry/configuration/BaSyxRegistryConfiguration.java
+++ b/basyx.components/basyx.components.docker/basyx.components.registry/src/main/java/org/eclipse/basyx/components/registry/configuration/BaSyxRegistryConfiguration.java
@@ -64,7 +64,7 @@ public class BaSyxRegistryConfiguration extends BaSyxConfiguration {
 	}
 
 	public void loadFromEnvironmentVariables() {
-		loadFromEnvironmentVariables(ENV_PREFIX, BACKEND, EVENTS, AUTHORIZATION_ENABLED);
+		loadFromEnvironmentVariables(ENV_PREFIX, BACKEND, EVENTS, AUTHORIZATION_ENABLED, TAGGED_DIRECTORY_ENABLED);
 	}
 
 	public void loadFromDefaultSource() {

--- a/basyx.components/basyx.components.docker/basyx.components.registry/src/main/java/org/eclipse/basyx/components/registry/mqtt/MqttRegistryFactory.java
+++ b/basyx.components/basyx.components.docker/basyx.components.registry/src/main/java/org/eclipse/basyx/components/registry/mqtt/MqttRegistryFactory.java
@@ -44,7 +44,7 @@ public class MqttRegistryFactory {
 		MqttClientPersistence mqttPersistence = getMqttPersistenceFromConfig(mqttConfig);
 		try {
 			MqttAASRegistryServiceObserver mqttObserver = new MqttAASRegistryServiceObserver(brokerEndpoint,
-					REGISTRY_CLIENT_ID, mqttPersistence);
+					REGISTRY_CLIENT_ID, mqttConfig.getUser(), mqttConfig.getPass().toCharArray(), mqttPersistence);
 			observedAPI.addObserver(mqttObserver);
 		} catch (MqttException e) {
 			logger.error("Could not establish MQTT connection for MqttAASRegistry", e);


### PR DESCRIPTION
One may specify MQTT credentials in params / env, but they are never used.
Additionally adding param "registry.taggedDirectoryEnabled" to env scan.