### PR TITLE
Renames DynamicActivitiProcessTest to DynamicCamundaProcessTest

### DIFF
--- a/basyx.components/basyx.components.lib/src/test/java/org/eclipse/basyx/regression/processengineconnector/DynamicCamundaProcessTest.java
+++ b/basyx.components/basyx.components.lib/src/test/java/org/eclipse/basyx/regression/processengineconnector/DynamicCamundaProcessTest.java
@@ -49,7 +49,7 @@ import org.junit.Test;
  * @author zhangzai
  *
  */
-public class DynamicActivitiProcessTest {
+public class DynamicCamundaProcessTest {
 	
 	/**
 	 * Process instance to be executed


### PR DESCRIPTION
Dear Frank,

This PR renames DynamicActivitiProcessTest to DynamicCamundaProcessTest in components.lib.

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>