### PR TITLE
Add support for exterior Updater-configs

### DIFF
--- a/basyx.components/basyx.components.updater/basyx.components.updater.core/src/main/java/basyx/components/updater/core/configuration/loader/FileConfigurationLoader.java
+++ b/basyx.components/basyx.components.updater/basyx.components.updater.core/src/main/java/basyx/components/updater/core/configuration/loader/FileConfigurationLoader.java
@@ -12,10 +12,7 @@
 
 package basyx.components.updater.core.configuration.loader;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,7 +74,13 @@ public class FileConfigurationLoader {
 	 * @return
 	 */
 	private InputStreamReader getJsonReader() {
-		InputStream stream = loader.getResourceAsStream(filePath);
+		InputStream stream = null;
+	    try {
+			stream = new FileInputStream(filePath);
+		} catch (Exception e) {
+	        logger.error("Could not open the file");
+	        e.printStackTrace();
+		}
 		InputStreamReader reader = null;
 		try {
 			reader = new InputStreamReader(stream, "UTF-8");

--- a/basyx.components/basyx.components.updater/basyx.components.updater.core/src/main/java/basyx/components/updater/core/configuration/loader/FileConfigurationLoader.java
+++ b/basyx.components/basyx.components.updater/basyx.components.updater.core/src/main/java/basyx/components/updater/core/configuration/loader/FileConfigurationLoader.java
@@ -74,13 +74,21 @@ public class FileConfigurationLoader {
 	 * @return
 	 */
 	private InputStreamReader getJsonReader() {
+
 		InputStream stream = null;
 	    try {
 			stream = new FileInputStream(filePath);
-		} catch (Exception e) {
-	        logger.error("Could not open the file");
-	        e.printStackTrace();
+		} catch (Exception e1) {
+	        logger.warn("No exterior config file found in defined path. Trying to load config file from classpath...");
+	        try {
+				stream = loader.getResourceAsStream(filePath);
+			} catch (Exception e2) {
+				logger.error("No exterior config file found in defined path and no config file found in classpath");
+				e2.printStackTrace();
+			}
 		}
+
+
 		InputStreamReader reader = null;
 		try {
 			reader = new InputStreamReader(stream, "UTF-8");

--- a/basyx.components/basyx.components.updater/basyx.components.updater.transformer.camel-jsonata/src/main/java/basyx/components/updater/transformer/cameljsonata/configuration/JsonataTransformerConfiguration.java
+++ b/basyx.components/basyx.components.updater/basyx.components.updater.transformer.camel-jsonata/src/main/java/basyx/components/updater/transformer/cameljsonata/configuration/JsonataTransformerConfiguration.java
@@ -12,6 +12,8 @@
 package basyx.components.updater.transformer.cameljsonata.configuration;
 
 import basyx.components.updater.core.configuration.DataTransformerConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
@@ -23,6 +25,7 @@ import java.io.File;
  *
  */
 public class JsonataTransformerConfiguration extends DataTransformerConfiguration {
+	private static final Logger logger = LoggerFactory.getLogger(JsonataTransformerConfiguration.class);
 	private String queryPath;
 	private String inputType;
 	private String outputType;
@@ -49,10 +52,10 @@ public class JsonataTransformerConfiguration extends DataTransformerConfiguratio
 		File jsonataFile = new File(getQueryPath());
 
 		if (jsonataFile.exists()) {
-		    System.out.println("Looking for jsonata config as configured in jsonatatransformer.json...");
+			logger.info("Looking for jsonata config as configured in jsonatatransformer.json...");
 			url = "jsonata:" + "file:./" + getQueryPath() + "?inputType=" + getInputType() + "&outputType=" + getOutputType();
 		} else {
-			System.out.println("Couldn't find jsonata config as configured in jsonatatransformer.json. Looking in classpath...");
+			logger.info("Couldn't find jsonata config as configured in jsonatatransformer.json. Looking in classpath...");
 			url = "jsonata:" + getQueryPath() + "?inputType=" + getInputType() + "&outputType=" + getOutputType();
 		}
 		return url;

--- a/basyx.components/basyx.components.updater/basyx.components.updater.transformer.camel-jsonata/src/main/java/basyx/components/updater/transformer/cameljsonata/configuration/JsonataTransformerConfiguration.java
+++ b/basyx.components/basyx.components.updater/basyx.components.updater.transformer.camel-jsonata/src/main/java/basyx/components/updater/transformer/cameljsonata/configuration/JsonataTransformerConfiguration.java
@@ -13,6 +13,8 @@ package basyx.components.updater.transformer.cameljsonata.configuration;
 
 import basyx.components.updater.core.configuration.DataTransformerConfiguration;
 
+import java.io.File;
+
 /**
  * An implementation of Jsonata transformer configuration
  * using camel jsonata component
@@ -43,7 +45,16 @@ public class JsonataTransformerConfiguration extends DataTransformerConfiguratio
 	}
 
 	public String getConnectionURI() {
-		String url = "jsonata:" + "file:./"  + getQueryPath() + "?inputType=" + getInputType() + "&outputType=" + getOutputType();
+		String url = "";
+		File jsonataFile = new File(getQueryPath());
+
+		if (jsonataFile.exists()) {
+		    System.out.println("Looking for jsonata config as configured in jsonatatransformer.json...");
+			url = "jsonata:" + "file:./" + getQueryPath() + "?inputType=" + getInputType() + "&outputType=" + getOutputType();
+		} else {
+			System.out.println("Couldn't find jsonata config as configured in jsonatatransformer.json. Looking in classpath...");
+			url = "jsonata:" + getQueryPath() + "?inputType=" + getInputType() + "&outputType=" + getOutputType();
+		}
 		return url;
 	}
 

--- a/basyx.components/basyx.components.updater/basyx.components.updater.transformer.camel-jsonata/src/main/java/basyx/components/updater/transformer/cameljsonata/configuration/JsonataTransformerConfiguration.java
+++ b/basyx.components/basyx.components.updater/basyx.components.updater.transformer.camel-jsonata/src/main/java/basyx/components/updater/transformer/cameljsonata/configuration/JsonataTransformerConfiguration.java
@@ -43,7 +43,7 @@ public class JsonataTransformerConfiguration extends DataTransformerConfiguratio
 	}
 
 	public String getConnectionURI() {
-		String url = "jsonata:" + getQueryPath() + "?inputType=" + getInputType() + "&outputType=" + getOutputType();
+		String url = "jsonata:" + "file:./"  + getQueryPath() + "?inputType=" + getInputType() + "&outputType=" + getOutputType();
 		return url;
 	}
 


### PR DESCRIPTION
Closes #65 

Updater Config files can be read outside from packed jar or Docker Container.
This allows the configuration of the packed application in deployment.

As a demonstration, consider [this docker-compose repo](https://github.com/n14s/prometheus-aas-docker), which uses a route that connects Prometheus to the AAS. 
It incorporates the changes of this PR.

For further information on how to build a Updater application that reads exterior config files, examine the pom of [this Updater application](https://github.com/n14s/prometheus-aas-router), that is used in the compose stack mentioned above.