### PR TITLE
fix doublequotes in string exchange message

### DIFF
--- a/basyx.components/basyx.components.updater/basyx.components.updater.camel-aas/src/main/java/basyx/components/updater/aas/AASProducer.java
+++ b/basyx.components/basyx.components.updater/basyx.components.updater.camel-aas/src/main/java/basyx/components/updater/aas/AASProducer.java
@@ -44,10 +44,12 @@ public class AASProducer extends DefaultProducer {
 
     String fixMessage(String messageBody) {
 		String fixedMessageBody = "";
-		if (messageBody.contains("\"") && messageBody != null && messageBody.isEmpty() == false) {
-			fixedMessageBody = messageBody.substring(1,messageBody.length() - 1);
-		} else {
-			fixedMessageBody = messageBody;
+		if (messageBody != null) {
+			if (messageBody.startsWith("\"") && messageBody.endsWith("\"")) {
+				fixedMessageBody = messageBody.substring(1,messageBody.length() - 1);
+			} else {
+				fixedMessageBody = messageBody;
+			}
 		}
 		return fixedMessageBody;
 	}

--- a/basyx.components/basyx.components.updater/basyx.components.updater.camel-aas/src/main/java/basyx/components/updater/aas/AASProducer.java
+++ b/basyx.components/basyx.components.updater/basyx.components.updater.camel-aas/src/main/java/basyx/components/updater/aas/AASProducer.java
@@ -34,9 +34,23 @@ public class AASProducer extends DefaultProducer {
 
 	@Override
 	public void process(Exchange exchange) throws Exception {
-		LOG.info("Got msg for property: " + exchange.getMessage().getBody(String.class));
-    	connectedProperty.setValue(exchange.getMessage().getBody(String.class));
+    	String messageBody = exchange.getMessage().getBody(String.class);
+		String fixedMessageBody = "";
+    	fixedMessageBody = fixMessage(messageBody);
+
+		LOG.info("Got msg for property: " + fixedMessageBody);
+    	connectedProperty.setValue(fixedMessageBody);
     }
+
+    String fixMessage(String messageBody) {
+		String fixedMessageBody = "";
+		if (messageBody.contains("\"") && messageBody != null && messageBody.isEmpty() == false) {
+			fixedMessageBody = messageBody.substring(1,messageBody.length() - 1);
+		} else {
+			fixedMessageBody = messageBody;
+		}
+		return fixedMessageBody;
+	}
 	
 	/**
 	 * Connect the the Submodel Element for data dumping


### PR DESCRIPTION
Address #74

Quick fix for double quote problem in string exchange messages.

Trims quotes in received message:
That means, it produces the dired AAS state, but doesn't fix the internal bug.

Use this PR as a temporal solution until the reason for the bug is found.