### PR TITLE
adds missing implementation link of the UpdaterComponent to the IComponent

### DIFF
--- a/basyx.components/basyx.components.updater/basyx.components.updater.core/pom.xml
+++ b/basyx.components/basyx.components.updater/basyx.components.updater.core/pom.xml
@@ -79,7 +79,6 @@
             <groupId>org.eclipse.basyx</groupId>
             <artifactId>basyx.components.lib</artifactId>
             <version>1.0.2</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/basyx.components/basyx.components.updater/basyx.components.updater.core/pom.xml
+++ b/basyx.components/basyx.components.updater/basyx.components.updater.core/pom.xml
@@ -75,5 +75,11 @@
 			<artifactId>gson</artifactId>
 			<version>2.8.9</version>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.eclipse.basyx</groupId>
+            <artifactId>basyx.components.lib</artifactId>
+            <version>1.0.2</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/basyx.components/basyx.components.updater/basyx.components.updater.core/src/main/java/basyx/components/updater/core/component/UpdaterComponent.java
+++ b/basyx.components/basyx.components.updater/basyx.components.updater.core/src/main/java/basyx/components/updater/core/component/UpdaterComponent.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import org.apache.camel.CamelContext;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.tooling.model.Strings;
+import org.eclipse.basyx.components.IComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,7 @@ import basyx.components.updater.core.routebuilder.UpdaterRouteBuilder;
  * @author haque
  *
  */
-public class UpdaterComponent {
+public class UpdaterComponent implements IComponent {
 	private static Logger logger = LoggerFactory.getLogger(UpdaterComponent.class);
 	private RoutesConfiguration routesWithoutDelegator;
 	private RoutesConfiguration delegatorRoutes;

--- a/basyx.components/basyx.components.updater/basyx.components.updater.core/src/main/java/basyx/components/updater/core/component/UpdaterComponent.java
+++ b/basyx.components/basyx.components.updater/basyx.components.updater.core/src/main/java/basyx/components/updater/core/component/UpdaterComponent.java
@@ -49,6 +49,7 @@ public class UpdaterComponent implements IComponent {
 	/**
 	 * Starts the Camel component
 	 */
+	@Override
 	public void startComponent() {
 		startRoutesWithoutDelegator();
 		startDelegatoRoutes();
@@ -97,6 +98,7 @@ public class UpdaterComponent implements IComponent {
 	/**
 	 * Stops the Camel component
 	 */
+	@Override
 	public void stopComponent() {
 		if (camelContext != null && !camelContext.isStopped()) {
 			camelContext.stop();


### PR DESCRIPTION
adds missing dependency/implementation of the Updater Core `UpdaterComponent` to the `IComponent` interface, so it can be used similar to `AASServerComponent` and `RegistryComponent` ...

The version of the added dependency on the BaSyx `basyx.components.lib` can be changed, I just adapted it from the current `main` branch.