### PR TITLE
Demonstrate issue: Submodel Aggregator does not support multiple Subm…

### DIFF
--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mongodb/MongoDBAASAggregator.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mongodb/MongoDBAASAggregator.java
@@ -45,7 +45,7 @@ import org.eclipse.basyx.aas.restapi.api.IAASAPI;
 import org.eclipse.basyx.aas.restapi.api.IAASAPIFactory;
 import org.eclipse.basyx.components.aas.aascomponent.InMemoryAASServerComponentFactory;
 import org.eclipse.basyx.components.configuration.BaSyxMongoDBConfiguration;
-import org.eclipse.basyx.submodel.aggregator.SubmodelAggregator;
+import org.eclipse.basyx.submodel.aggregator.SubmodelAggregatorFactory;
 import org.eclipse.basyx.submodel.aggregator.api.ISubmodelAggregator;
 import org.eclipse.basyx.submodel.aggregator.api.ISubmodelAggregatorFactory;
 import org.eclipse.basyx.submodel.metamodel.api.identifier.IIdentifier;
@@ -106,7 +106,10 @@ public class MongoDBAASAggregator implements IAASAggregator {
 
 	/**
 	 * Store SubmodelAggregator. By default, uses standard SubmodelAggregator
+	 * 
+	 * @deprecated Please use {@link #submodelAggregatorFactory}
 	 */
+	@Deprecated
 	protected ISubmodelAggregator submodelAggregator;
 	protected ISubmodelAggregatorFactory submodelAggregatorFactory;
 
@@ -123,7 +126,7 @@ public class MongoDBAASAggregator implements IAASAggregator {
 	@Deprecated
 	public MongoDBAASAggregator(BaSyxMongoDBConfiguration config) {
 		this.setConfiguration(config);
-		submodelAggregator = new SubmodelAggregator(smApiProvider);
+		submodelAggregatorFactory = new SubmodelAggregatorFactory(smApiProvider);
 		init();
 	}
 
@@ -143,7 +146,7 @@ public class MongoDBAASAggregator implements IAASAggregator {
 	public MongoDBAASAggregator(BaSyxMongoDBConfiguration config, IAASRegistry registry) {
 		this.setConfiguration(config);
 		this.registry = registry;
-		submodelAggregator = new SubmodelAggregator(smApiProvider);
+		submodelAggregatorFactory = new SubmodelAggregatorFactory(smApiProvider);
 		init();
 	}
 
@@ -162,7 +165,7 @@ public class MongoDBAASAggregator implements IAASAggregator {
 		config = new BaSyxMongoDBConfiguration();
 		config.loadFromResource(resourceConfigPath);
 		this.setConfiguration(config);
-		submodelAggregator = new SubmodelAggregator(smApiProvider);
+		submodelAggregatorFactory = new SubmodelAggregatorFactory(smApiProvider);
 		init();
 	}
 
@@ -182,7 +185,7 @@ public class MongoDBAASAggregator implements IAASAggregator {
 		config = new BaSyxMongoDBConfiguration();
 		config.loadFromResource(resourceConfigPath);
 		this.setConfiguration(config);
-		submodelAggregator = new SubmodelAggregator(smApiProvider);
+		submodelAggregatorFactory = new SubmodelAggregatorFactory(smApiProvider);
 		this.registry = registry;
 		init();
 	}

--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mongodb/MongoDBAASAggregator.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mongodb/MongoDBAASAggregator.java
@@ -46,6 +46,7 @@ import org.eclipse.basyx.aas.restapi.api.IAASAPIFactory;
 import org.eclipse.basyx.components.aas.aascomponent.InMemoryAASServerComponentFactory;
 import org.eclipse.basyx.components.configuration.BaSyxMongoDBConfiguration;
 import org.eclipse.basyx.submodel.aggregator.SubmodelAggregator;
+import org.eclipse.basyx.submodel.aggregator.SubmodelAggregatorFactory;
 import org.eclipse.basyx.submodel.aggregator.api.ISubmodelAggregator;
 import org.eclipse.basyx.submodel.aggregator.api.ISubmodelAggregatorFactory;
 import org.eclipse.basyx.submodel.metamodel.api.identifier.IIdentifier;
@@ -380,6 +381,11 @@ public class MongoDBAASAggregator implements IAASAggregator {
 	private MultiSubmodelProvider createMultiSubmodelProvider(IAASAPI aasApi) {
 		AASModelProvider aasProvider = new AASModelProvider(aasApi);
 		IConnectorFactory connProvider = new HTTPConnectorFactory();
+
+		// quick-fix: init submodel aggregator per aas provider
+		//MongoDBSubmodelAPIFactory submodelAPIFactory = new MongoDBSubmodelAPIFactory(this.config);
+		//submodelAggregator = new SubmodelAggregatorFactory(submodelAPIFactory).create();
+
 		return new MultiSubmodelProvider(aasProvider, registry, connProvider, aasApiProvider, submodelAggregator);
 	}
 

--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mongodb/MongoDBAASAggregator.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mongodb/MongoDBAASAggregator.java
@@ -46,7 +46,6 @@ import org.eclipse.basyx.aas.restapi.api.IAASAPIFactory;
 import org.eclipse.basyx.components.aas.aascomponent.InMemoryAASServerComponentFactory;
 import org.eclipse.basyx.components.configuration.BaSyxMongoDBConfiguration;
 import org.eclipse.basyx.submodel.aggregator.SubmodelAggregator;
-import org.eclipse.basyx.submodel.aggregator.SubmodelAggregatorFactory;
 import org.eclipse.basyx.submodel.aggregator.api.ISubmodelAggregator;
 import org.eclipse.basyx.submodel.aggregator.api.ISubmodelAggregatorFactory;
 import org.eclipse.basyx.submodel.metamodel.api.identifier.IIdentifier;
@@ -109,6 +108,7 @@ public class MongoDBAASAggregator implements IAASAggregator {
 	 * Store SubmodelAggregator. By default, uses standard SubmodelAggregator
 	 */
 	protected ISubmodelAggregator submodelAggregator;
+	protected ISubmodelAggregatorFactory submodelAggregatorFactory;
 
 	/**
 	 * Receives a BaSyxMongoDBConfiguration and a registry to create a persistent
@@ -226,7 +226,7 @@ public class MongoDBAASAggregator implements IAASAggregator {
 		this.config = config;
 		this.registry = registry;
 		this.aasApiProvider = aasAPIFactory;
-		this.submodelAggregator = submodelAggregatorFactory.create();
+		this.submodelAggregatorFactory = submodelAggregatorFactory;
 		init();
 	}
 
@@ -243,7 +243,7 @@ public class MongoDBAASAggregator implements IAASAggregator {
 		setMongoDBConfiguration(config);
 		this.config = config;
 		this.aasApiProvider = aasAPIFactory;
-		this.submodelAggregator = submodelAggregatorFactory.create();
+		this.submodelAggregatorFactory = submodelAggregatorFactory;
 		init();
 	}
 
@@ -263,7 +263,7 @@ public class MongoDBAASAggregator implements IAASAggregator {
 		setMongoDBConfiguration(config);
 		this.registry = registry;
 		this.aasApiProvider = aasAPIFactory;
-		this.submodelAggregator = submodelAggregatorFactory.create();
+		this.submodelAggregatorFactory = submodelAggregatorFactory;
 		init();
 	}
 
@@ -281,7 +281,7 @@ public class MongoDBAASAggregator implements IAASAggregator {
 		config.loadFromResource(resourceConfigPath);
 		setMongoDBConfiguration(config);
 		this.aasApiProvider = aasAPIFactory;
-		this.submodelAggregator = submodelAggregatorFactory.create();
+		this.submodelAggregatorFactory = submodelAggregatorFactory;
 		init();
 	}
 
@@ -382,11 +382,17 @@ public class MongoDBAASAggregator implements IAASAggregator {
 		AASModelProvider aasProvider = new AASModelProvider(aasApi);
 		IConnectorFactory connProvider = new HTTPConnectorFactory();
 
-		// quick-fix: init submodel aggregator per aas provider
-		//MongoDBSubmodelAPIFactory submodelAPIFactory = new MongoDBSubmodelAPIFactory(this.config);
-		//submodelAggregator = new SubmodelAggregatorFactory(submodelAPIFactory).create();
+		ISubmodelAggregator usedAggregator = getSubmodelAggregatorInstance();
 
-		return new MultiSubmodelProvider(aasProvider, registry, connProvider, aasApiProvider, submodelAggregator);
+		return new MultiSubmodelProvider(aasProvider, registry, connProvider, aasApiProvider, usedAggregator);
+	}
+
+	private ISubmodelAggregator getSubmodelAggregatorInstance() {
+		if (submodelAggregatorFactory == null) {
+			return submodelAggregator;
+		}
+
+		return submodelAggregatorFactory.create();
 	}
 
 	/**


### PR DESCRIPTION
…odels with same idShort

https://github.com/eclipse-basyx/basyx-java-sdk/issues/47

* Instantiate SubmodelAggregator for each MultiSubmodelProvider
* Extend unit test to test two aas, each with one submodel and same idShort
* Add a quick-fix (currently commented out) to MongoDBAggregator (note: quick-fix is not copatibel with the current mqtt integration for submodels)

Signed-off-by: Matthias Stöhr <matthias.stoehr@ipa.fraunhofer.de>