### PR TITLE
Switching from alpine to bullseye and to fabric8

### DIFF
--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/Dockerfile
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/Dockerfile
@@ -1,7 +1,7 @@
-# Add java runtime environment for execution
-FROM alpine
+FROM openjdk:8-jdk-slim-bullseye
 
-RUN apk update && apk add openjdk8 && apk add bash && apk add jq
+# Install dependency for wait-for-it-env.sh
+RUN apt update && apt install -y jq && apt clean
 
 # Copy built jar to image using the jar name specified in the pom.xml (JAR_FILE)
 ARG JAR_FILE

--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/pom.xml
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/pom.xml
@@ -142,8 +142,8 @@
 
 					<!-- Build the docker image -->
 					<plugin>
-						<groupId>com.spotify</groupId>
-						<artifactId>dockerfile-maven-plugin</artifactId>
+						<groupId>io.fabric8</groupId>
+	                    <artifactId>docker-maven-plugin</artifactId>
 					</plugin>
 
 					<!-- Create integration test environment -->

--- a/basyx.components/basyx.components.docker/basyx.components.registry/Dockerfile
+++ b/basyx.components/basyx.components.docker/basyx.components.registry/Dockerfile
@@ -1,7 +1,4 @@
-# Add java runtime environment for execution
-FROM alpine
-
-RUN apk update && apk add openjdk8
+FROM openjdk:8-jdk-slim-bullseye
 
 # Copy built jar to image using the jar name specified in the pom.xml (JAR_FILE)
 ARG JAR_FILE

--- a/basyx.components/basyx.components.docker/basyx.components.registry/pom.xml
+++ b/basyx.components/basyx.components.docker/basyx.components.registry/pom.xml
@@ -122,8 +122,8 @@
 
 					<!-- Build the docker image -->
 					<plugin>
-						<groupId>com.spotify</groupId>
-						<artifactId>dockerfile-maven-plugin</artifactId>
+	                    <groupId>io.fabric8</groupId>
+	                    <artifactId>docker-maven-plugin</artifactId>
 					</plugin>
 
 					<!-- Create integration test environment -->

--- a/basyx.components/basyx.components.docker/pom.xml
+++ b/basyx.components/basyx.components.docker/pom.xml
@@ -93,33 +93,41 @@
 
 				<!-- Build the docker image -->
 				<plugin>
-					<groupId>com.spotify</groupId>
-					<artifactId>dockerfile-maven-plugin</artifactId>
-					<version>1.4.10</version>
-					<executions>
-						<execution>
-							<id>default</id>
-							<goals>
-								<goal>build</goal>
-							</goals>
-						</execution>
-					</executions>
-					<configuration>
-						<repository>${BASYX_IMAGE_NAME}</repository>
-						<tag>${BASYX_IMAGE_TAG}</tag>
-						<buildArgs>
-							<JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
-							<PORT>${BASYX_CONTAINER_PORT}</PORT>
-							<!-- The system property/env keys for basyx configuration files -->
-							<CONTEXT_CONFIG_KEY>BASYX_CONTEXT</CONTEXT_CONFIG_KEY>
-							<REGISTRY_CONFIG_KEY>BASYX_REGISTRY</REGISTRY_CONFIG_KEY>
-							<AAS_CONFIG_KEY>BASYX_AAS</AAS_CONFIG_KEY>
-							<MONGODB_CONFIG_KEY>BASYX_MONGODB</MONGODB_CONFIG_KEY>
-							<DOCKER_CONFIG_KEY>BASYX_DOCKER</DOCKER_CONFIG_KEY>
-							<SQL_CONFIG_KEY>BASYX_SQL</SQL_CONFIG_KEY>
-						</buildArgs>
-					</configuration>
-				</plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>0.39.1</version>
+                    <configuration>
+                        <images>
+                            <image>
+                                <name>${BASYX_IMAGE_NAME}:${BASYX_IMAGE_TAG}</name>
+                                <build>
+                                    <contextDir>${project.basedir}</contextDir>
+                                    <args>
+                                        <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+										<PORT>${BASYX_CONTAINER_PORT}</PORT>
+										<!-- The system property/env keys for basyx configuration files -->
+										<CONTEXT_CONFIG_KEY>BASYX_CONTEXT</CONTEXT_CONFIG_KEY>
+										<REGISTRY_CONFIG_KEY>BASYX_REGISTRY</REGISTRY_CONFIG_KEY>
+										<AAS_CONFIG_KEY>BASYX_AAS</AAS_CONFIG_KEY>
+										<MONGODB_CONFIG_KEY>BASYX_MONGODB</MONGODB_CONFIG_KEY>
+										<DOCKER_CONFIG_KEY>BASYX_DOCKER</DOCKER_CONFIG_KEY>
+										<SQL_CONFIG_KEY>BASYX_SQL</SQL_CONFIG_KEY>
+                                    </args>
+                                </build>
+                            </image>
+                        </images>
+                        <verbose>true</verbose>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>docker:build</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>build</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
 
 				<!-- Create integration test environment -->
 				<plugin>


### PR DESCRIPTION
To simplify docker multi-arch image handling, I would recommend to switch the openjdk:8-jdk-slim-bullseye base image.
This one combines different architectures within one docker tag, which enables much easier docker-compose handling.

On different archs, we can always use the same unmodified docker-compose file - in contrast to the alpine image, where we had to switch the docker tag, which leads to incompatible docker-compose files on different archs.

Additionally I switched to io.fabric8:docker-maven-plugin, which supports builds on mac m1; the deprecated spotify plugin doesn't...