### PR TITLE
javax replaced with jakarta

### DIFF
--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/test/java/org/eclipse/basyx/regression/AASServer/AASXSuite.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/test/java/org/eclipse/basyx/regression/AASServer/AASXSuite.java
@@ -31,11 +31,11 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
 
 import org.eclipse.basyx.aas.manager.ConnectedAssetAdministrationShellManager;
 import org.eclipse.basyx.aas.metamodel.connected.ConnectedAssetAdministrationShell;

--- a/basyx.components/basyx.components.docker/basyx.components.registry/src/test/java/org/eclipse/basyx/regression/registry/ITRegistryRaw.java
+++ b/basyx.components/basyx.components.docker/basyx.components.registry/src/test/java/org/eclipse/basyx/regression/registry/ITRegistryRaw.java
@@ -32,7 +32,7 @@ import java.net.URLEncoder;
 import java.util.Collection;
 import java.util.Map;
 
-import javax.ws.rs.NotFoundException;
+import jakarta.ws.rs.NotFoundException;
 
 import org.eclipse.basyx.aas.metamodel.map.descriptor.AASDescriptor;
 import org.eclipse.basyx.aas.metamodel.map.descriptor.ModelUrn;

--- a/basyx.components/basyx.components.lib/src/main/java/org/eclipse/basyx/tools/webserviceclient/WebServiceRawClient.java
+++ b/basyx.components/basyx.components.lib/src/main/java/org/eclipse/basyx/tools/webserviceclient/WebServiceRawClient.java
@@ -26,14 +26,14 @@ package org.eclipse.basyx.tools.webserviceclient;
 
 import java.io.Serializable;
 
-import javax.ws.rs.ServerErrorException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation.Builder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 


### PR DESCRIPTION
javax.ws.rs was moved to jakarta.ws.rs therefore replaced javax dependency with latest jakarta version