### PR TITLE
Enabling auto reconnect for mqtt connection

### DIFF
--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mqtt/MqttAASServerFeature.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/mqtt/MqttAASServerFeature.java
@@ -66,6 +66,7 @@ public class MqttAASServerFeature implements IAASServerFeature {
 
 	protected MqttConnectOptions createMqttConnectOptions() {
 		MqttConnectOptions options = new MqttConnectOptions();
+		options.setAutomaticReconnect(true);
 		if (!Strings.isNullOrEmpty(mqttConfig.getUser())) {
 			options.setUserName(mqttConfig.getUser());
 			options.setPassword(mqttConfig.getPass().toCharArray());

--- a/basyx.components/basyx.components.docker/basyx.components.registry/src/main/java/org/eclipse/basyx/components/registry/mqtt/MqttV2RegistryFactory.java
+++ b/basyx.components/basyx.components.docker/basyx.components.registry/src/main/java/org/eclipse/basyx/components/registry/mqtt/MqttV2RegistryFactory.java
@@ -78,6 +78,7 @@ public class MqttV2RegistryFactory {
 		MqttClient mqttClient = new MqttClient(mqttConfig.getServer(), mqttConfig.getClientId(), mqttPersistence);
 		
 		MqttConnectOptions options = new MqttConnectOptions();
+		options.setAutomaticReconnect(true);
 		options.setUserName(mqttConfig.getUser());
 		options.setPassword(mqttConfig.getPass().toCharArray());
 		


### PR DESCRIPTION
The mqtt connection should be self healing in cases when the mqtt broker connnect dies for whatever reason