### PR TITLE
Fix access control preventing mongodb boot up loading

### DIFF
--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/AASServerComponent.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/AASServerComponent.java
@@ -540,7 +540,9 @@ public class AASServerComponent implements IComponent {
 
 	private IAASAggregator createAASAggregator() {
 		if (isMongoDBBackend()) {
-			return new MongoDBAASServerComponentFactory(createMongoDbConfiguration(), createAASServerDecoratorList(), registry).create();
+			try (final var ignored = ElevatedCodeAuthentication.enterElevatedCodeAuthenticationArea()) {
+				return new MongoDBAASServerComponentFactory(createMongoDbConfiguration(), createAASServerDecoratorList(), registry).create();
+			}
 		}
 		return new InMemoryAASServerComponentFactory(createAASServerDecoratorList(), registry).create();
 	}

--- a/basyx.components/basyx.components.docker/basyx.components.registry/src/main/java/org/eclipse/basyx/components/registry/RegistryComponent.java
+++ b/basyx.components/basyx.components.docker/basyx.components.registry/src/main/java/org/eclipse/basyx/components/registry/RegistryComponent.java
@@ -52,6 +52,7 @@ import org.eclipse.basyx.components.security.authorization.internal.Authorizatio
 import org.eclipse.basyx.components.security.authorization.internal.IJwtBearerTokenAuthenticationConfigurationProvider;
 import org.eclipse.basyx.extensions.aas.directory.tagged.api.IAASTaggedDirectory;
 import org.eclipse.basyx.extensions.aas.directory.tagged.map.MapTaggedDirectory;
+import org.eclipse.basyx.extensions.shared.authorization.internal.ElevatedCodeAuthentication;
 import org.eclipse.basyx.extensions.shared.encoding.Base64URLEncoder;
 import org.eclipse.basyx.extensions.shared.encoding.URLEncoder;
 import org.eclipse.basyx.vab.protocol.http.server.BaSyxContext;
@@ -263,7 +264,9 @@ public class RegistryComponent implements IComponent {
 		logger.info("Enable tagged directory functionality");
 		IAASTaggedDirectory taggedDirectory;
 		if (registryConfig.getRegistryBackend().equals(RegistryBackend.MONGODB)) {
-			taggedDirectory = new MongoDBTaggedDirectory(loadMongoDBConfiguration(), new HashMap<>());
+			try (final var ignored = ElevatedCodeAuthentication.enterElevatedCodeAuthenticationArea()) {
+				taggedDirectory = new MongoDBTaggedDirectory(loadMongoDBConfiguration(), new HashMap<>());
+			}
 		} else {
 			taggedDirectory = new MapTaggedDirectory(new HashedMap<>(), new HashedMap<>());
 		}
@@ -336,7 +339,9 @@ public class RegistryComponent implements IComponent {
 	private IAASRegistry createMongoDBRegistryBackend() {
 		logger.info("Creating MongoDBRegistry");
 		final BaSyxMongoDBConfiguration mongoDBConfiguration = loadMongoDBConfiguration();
-		return new MongoDBRegistry(mongoDBConfiguration);
+		try (final var ignored = ElevatedCodeAuthentication.enterElevatedCodeAuthenticationArea()) {
+			return new MongoDBRegistry(mongoDBConfiguration);
+		}
 	}
 
 	private IAASRegistry decorate(IAASRegistry aasRegistry) {


### PR DESCRIPTION
Signed-off-by: wege <florian.wege@iese.fraunhofer.de>

When access control was enabled and mongodb used, the boot up code would read existing data from the mongodb and add basyx objects to the memory but was impeded by the access control without a security context.