### PR TITLE
Adapts the AASXToMetamodelConverter usage as per changes in SDK

### DIFF
--- a/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/AASServerComponent.java
+++ b/basyx.components/basyx.components.docker/basyx.components.AASServer/src/main/java/org/eclipse/basyx/components/aas/AASServerComponent.java
@@ -557,13 +557,14 @@ public class AASServerComponent implements IComponent {
 		logger.info("Loading aas from aasx \"" + aasxPath + "\"");
 
 		// Instantiate the aasx package manager
-		AASXToMetamodelConverter packageManager = new AASXPackageManager(aasxPath);
+		try (AASXToMetamodelConverter packageManager = new AASXToMetamodelConverter(aasxPath)) {
+			// Unpack the files referenced by the aas
+			packageManager.unzipRelatedFiles();
 
-		// Unpack the files referenced by the aas
-		packageManager.unzipRelatedFiles();
-
-		// Retrieve the aas from the package
-		return packageManager.retrieveAASBundles();
+			// Retrieve the aas from the package
+			return packageManager.retrieveAASBundles();
+		}
+		
 	}
 
 	private void addAASServerFeaturesToContext(BaSyxContext context) {


### PR DESCRIPTION
- Adapts the changes done in the SDK [eclipse-basyx/basyx-java-sdk#305]
- Replaces deprecated usage of AASXPackageManager with AASXToMetamodelConverter

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>